### PR TITLE
Support for empty result

### DIFF
--- a/src/mock/server.go
+++ b/src/mock/server.go
@@ -32,6 +32,9 @@ type FIFOReponseHandler struct {
 
 // ServeHTTP implementation of `http.Handler`
 func (srh *FIFOReponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if len(srh.Responses) == 0 {
+		return
+	}
 	if srh.CurrentIndex > len(srh.Responses) {
 		panic(fmt.Sprintf(
 			"go-github-mock: no more mocks available for %s",
@@ -102,7 +105,9 @@ func (prh *PaginatedReponseHandler) generateLinkHeader(
 // ServeHTTP implementation of `http.Handler`
 func (prh *PaginatedReponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	prh.generateLinkHeader(w, r)
-	w.Write(prh.ResponsePages[prh.getCurrentPage(r)-1])
+	if len(prh.ResponsePages) != 0 {
+		w.Write(prh.ResponsePages[prh.getCurrentPage(r)-1])
+	}
 }
 
 // EnforceHostRoundTripper rewrites all requests with the given `Host`.

--- a/src/mock/server_test.go
+++ b/src/mock/server_test.go
@@ -235,3 +235,44 @@ func TestMocksPaginationAllPages(t *testing.T) {
 		t.Errorf("len(allRepos) is %d, want 4", len(allRepos))
 	}
 }
+
+func TestMocksEmptyResult(t *testing.T) {
+	mockedHTTPClient := NewMockedHTTPClient(
+		WithRequestMatch(
+			GetReposReleasesByOwnerByRepo,
+			[][]byte{},
+		),
+		WithRequestMatchPages(
+			GetReposCommitsByOwnerByRepo,
+			[][]byte{},
+		),
+	)
+	c := github.NewClient(mockedHTTPClient)
+
+	ctx := context.Background()
+
+	releases, _, releaseErr := c.Repositories.ListReleases(ctx, "thecompany", "therepo", &github.ListOptions{})
+
+	if releases != nil {
+		t.Fatalf("releases is %s, want nil", releases)
+	}
+
+	if releaseErr != nil {
+		t.Errorf("releases err is %s, want nil", releaseErr.Error())
+	}
+
+	commits, _, orgsErr := c.Repositories.ListCommits(
+		ctx,
+		"thecompany",
+		"repo",
+		&github.CommitsListOptions{},
+	)
+
+	if len(commits) != 0 {
+		t.Errorf("commits len is %d want 0", len(commits))
+	}
+
+	if orgsErr != nil {
+		t.Errorf("orgs err is %s, want nil", orgsErr.Error())
+	}
+}


### PR DESCRIPTION
This PR adds support for the cases when empty data should be returned (for example if no releases exists - Github returns `http 200` with empty array in this case )