### PR TITLE
feat: add WithRateLimit as a new MockBackendOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 A library to aid unittesting code that uses Golang's Github SDK
 
-# Installation
+## Installation
 
 ```bash
 go get github.com/migueleliasweb/go-github-mock
 ```
 
-# Features
+## Features
 
 - Create mocks for successive calls for the same endpoint
 - Pagination support
@@ -17,18 +17,18 @@ go get github.com/migueleliasweb/go-github-mock
 - High level abstraction helps writing readabe unittests (see `mock.WithRequestMatch`)
 - Lower level abstraction for advanced uses (see `mock.WithRequestMatchHandler`)
 
-# Breaking changes
+## Breaking changes
 
 - `v0.0.3` the API for the server options have beem simplified
 - `v0.0.4` fixes to the gen script caused multiple url matches to change
 
-# Example
+## Examples
 
-```
+```go
 import "github.com/migueleliasweb/go-github-mock/src/mock"
 ```
 
-## Multiple requests
+### Multiple requests
 
 ```golang
 mockedHTTPClient := mock.NewMockedHTTPClient(
@@ -87,7 +87,7 @@ projs, _, projsErr := c.Organizations.ListProjects(
 
 ```
 
-## Returning empty results
+### Returning empty results
 
 ```golang
 mockedHTTPClient := NewMockedHTTPClient(
@@ -122,7 +122,7 @@ issues2, _, repo2Err := c.Issues.ListByRepo(ctx, "owner1", "repo2", &github.Issu
 // repo2Err == nil
 ```
 
-## Mocking errors from the API
+### Mocking errors from the API
 
 ```golang
 mockedHTTPClient := mock.NewMockedHTTPClient(
@@ -145,7 +145,7 @@ user, _, userErr := c.Users.Get(ctx, "someUser")
 
 // user == nil
 
-if userErr == nil {	
+if userErr == nil {
     if ghErr, ok := userErr.(*github.ErrorResponse); ok {
         fmt.Println(ghErr.Message) // == "github went belly up or something"
     }
@@ -153,7 +153,7 @@ if userErr == nil {
 
 ```
 
-## Mocking with pagination
+### Mocking with pagination
 
 ```golang
 mockedHTTPClient := NewMockedHTTPClient(
@@ -214,7 +214,7 @@ for {
 // len(allRepos) == 4
 ```
 
-## Mocking for Github Enterprise
+### Mocking for GitHub Enterprise
 
 Github Enterprise uses a different prefix for its endpoints. In order to use the correct endpoints, please use the different set of `*Enterprise` options:
 
@@ -240,16 +240,37 @@ user, _, userErr := c.Users.Get(ctx, "myuser")
 // user.Name == "foobar"
 ```
 
-# Why
+### Mocking with rate limits
 
-Some conversations got started on [go-github#1800](https://github.com/google/go-github/issues/1800) since `go-github` didn't provide an interface that could be easily reimplemented for unittests. After lots of conversations from the folks from [go-github](https://github.com/google/go-github) and quite a few PR ideas later, this style of testing was deemed not suitable to be part of the core SDK as it's not a feature of the API itself. Nonetheless, the ability of writing unittests for code that uses the `go-github` package is critical. 
+`WithRateLimit` uses a single rate-limiting middleware across all endpoints on the mock router.
+
+**NOTE:** This is an alpha feature. Future changes might break compatibility, until a stable version is released.
+
+```go
+  mhc := mock.NewMockedHTTPClient(
+    mock.WithRequestMatchPages(
+      mock.GetOrgsReposByOrg,
+      []github.Repository{{Name: github.String(repoOne)}},
+      []github.Repository{{Name: github.String(repoTwo)}},
+    ),
+
+    // The rate limiter will allow 10 requests per second, and a burst size of 1.
+    // These two options together mean that the rate of requests will be strictly enforced, so if any two requests are
+    // made less than 1/10th of a second apart, the latter will be refused and come back with a rate limit error.
+    mock.WithRateLimit(10, 1),
+  )
+```
+
+## Why
+
+Some conversations got started on [go-github#1800](https://github.com/google/go-github/issues/1800) since `go-github` didn't provide an interface that could be easily reimplemented for unittests. After lots of conversations from the folks from [go-github](https://github.com/google/go-github) and quite a few PR ideas later, this style of testing was deemed not suitable to be part of the core SDK as it's not a feature of the API itself. Nonetheless, the ability of writing unittests for code that uses the `go-github` package is critical.
 
 A reuseable, and not overly verbose, way of writing the tests was reached after some more interactions (months down the line) and here we are.
 
-# Thanks
+## Thanks
 
 Thanks for all ideas and feedback from the folks in [go-github](https://github.com/google/go-github/).
 
-# License
+## License
 
 This library is distributed under the MIT License found in LICENSE.

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/google/go-github/v56 v56.0.0
 	github.com/gorilla/mux v1.8.0
+	golang.org/x/time v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -13,4 +13,6 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/src/mock/server_options.go
+++ b/src/mock/server_options.go
@@ -159,6 +159,7 @@ func rateLimitMiddleware(rps float64, burst int) func(next http.Handler) http.Ha
 }
 
 // WithRateLimit enforces a rate limit on the mocked [http.Client].
+// NOTE: This is an alpha feature. Future changes might break compatibility, until a stable version is released.
 func WithRateLimit(rps float64, burst int) MockBackendOption {
 	return func(router *mux.Router) {
 		router.Use(rateLimitMiddleware(rps, burst))

--- a/src/mock/server_options_external_test.go
+++ b/src/mock/server_options_external_test.go
@@ -25,8 +25,10 @@ func TestWithRateLimit(t *testing.T) {
 			[]github.Repository{{Name: github.String(repoTwo)}},
 		),
 
-		// The rate limiter will allow 10 requests per second.
-		mock.WithRateLimit(10),
+		// The rate limiter will allow 10 requests per second, and a burst size of 1.
+		// These two options together mean that the rate of requests will be strictly enforced, so if any two requests are
+		// made less than 1/10th of a second apart, the latter will be refused and come back with a rate limit error.
+		mock.WithRateLimit(10, 1),
 	)
 
 	ghc := github.NewClient(mhc)
@@ -45,7 +47,8 @@ func TestWithRateLimit(t *testing.T) {
 
 			rleCount++
 
-			// Sleeping for one tenth of a second should be enough for the rate limiter on the mock server.
+			// After hitting the rate limiter and getting the appropriate error above, sleeping for one tenth of a second
+			// should be enough to reset the limiter and try requesting the repo list again.
 			time.Sleep(time.Second / 10)
 
 			continue

--- a/src/mock/server_options_external_test.go
+++ b/src/mock/server_options_external_test.go
@@ -1,0 +1,75 @@
+package mock_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v56/github"
+	"github.com/migueleliasweb/go-github-mock/src/mock"
+)
+
+func TestWithRateLimit(t *testing.T) {
+	t.Parallel()
+
+	const (
+		repoOne = "repo-one"
+		repoTwo = "repo-two"
+	)
+
+	mhc := mock.NewMockedHTTPClient(
+		mock.WithRequestMatchPages(
+			mock.GetOrgsReposByOrg,
+			[]github.Repository{{Name: github.String(repoOne)}},
+			[]github.Repository{{Name: github.String(repoTwo)}},
+		),
+
+		// The rate limiter will allow 10 requests per second.
+		mock.WithRateLimit(10),
+	)
+
+	ghc := github.NewClient(mhc)
+	opts := &github.RepositoryListByOrgOptions{}
+	repoNames := []string{}
+	rleCount := 0
+
+	for {
+		repos, resp, err := ghc.Repositories.ListByOrg(context.Background(), "org", opts)
+		if err != nil {
+			// The only type of error we expect is one from the rate limiter.
+			if _, ok := err.(*github.RateLimitError); !ok {
+				t.Fatalf("error is not a github.RateLimitError: %v", err)
+			}
+
+			rleCount++
+
+			// Sleeping for one tenth of a second should be enough for the rate limiter on the mock server.
+			time.Sleep(time.Second / 10)
+
+			continue
+		}
+		defer resp.Body.Close()
+
+		if len(repos) != 1 {
+			t.Fatal("should receive one repo per page from mock")
+		}
+
+		// Save the returned repo name to our slice, to assert against later.
+		repoNames = append(repoNames, repos[0].GetName())
+
+		// Handle pagination.
+		if resp.NextPage == 0 {
+			break
+		}
+
+		opts.Page = resp.NextPage
+	}
+
+	if len(repoNames) != 2 || repoNames[0] != repoOne || repoNames[1] != repoTwo {
+		t.Fatalf("list of returned repo names is wrong: %v", repoNames)
+	}
+
+	if rleCount != 1 {
+		t.Fatal("did not receive the expected number of github.RateLimitError")
+	}
+}

--- a/src/mock/server_options_external_test.go
+++ b/src/mock/server_options_external_test.go
@@ -2,6 +2,7 @@ package mock_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -37,7 +38,8 @@ func TestWithRateLimit(t *testing.T) {
 		repos, resp, err := ghc.Repositories.ListByOrg(context.Background(), "org", opts)
 		if err != nil {
 			// The only type of error we expect is one from the rate limiter.
-			if _, ok := err.(*github.RateLimitError); !ok {
+			var rle *github.RateLimitError
+			if !errors.As(err, &rle) {
 				t.Fatalf("error is not a github.RateLimitError: %v", err)
 			}
 


### PR DESCRIPTION
Use [the rate limiter from golang.org/x/time](https://pkg.go.dev/golang.org/x/time/rate#Limiter.Allow) to provide a new `MockBackendOption`: `WithRateLimit`

Resolves migueleliasweb/go-github-mock#57.