### PR TITLE
Fix out of index panic

### DIFF
--- a/src/mock/server.go
+++ b/src/mock/server.go
@@ -37,7 +37,7 @@ func (srh *FIFOResponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	srh.lock.Lock()
 	defer srh.lock.Unlock()
 
-	if srh.CurrentIndex > len(srh.Responses) {
+	if srh.CurrentIndex >= len(srh.Responses) {
 		panic(fmt.Sprintf(
 			"go-github-mock: no more mocks available for %s",
 			r.URL.Path,

--- a/src/mock/server.go
+++ b/src/mock/server.go
@@ -22,18 +22,18 @@ type EndpointPattern struct {
 // for the mocked backend
 type MockBackendOption func(*mux.Router)
 
-// FIFOReponseHandler handler implementation that
+// FIFOResponseHandler handler implementation that
 // responds to the HTTP requests following a FIFO approach.
 //
 // Once all available `Responses` have been used, this handler will panic()!
-type FIFOReponseHandler struct {
+type FIFOResponseHandler struct {
 	lock         sync.Mutex
 	Responses    [][]byte
 	CurrentIndex int
 }
 
 // ServeHTTP implementation of `http.Handler`
-func (srh *FIFOReponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (srh *FIFOResponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	srh.lock.Lock()
 	defer srh.lock.Unlock()
 
@@ -51,7 +51,7 @@ func (srh *FIFOReponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	w.Write(srh.Responses[srh.CurrentIndex])
 }
 
-// PaginatedReponseHandler handler implementation that
+// PaginatedResponseHandler handler implementation that
 // responds to the HTTP requests and honors the pagination headers
 //
 //	Header e.g: `Link: <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=15>; rel="next",
@@ -60,11 +60,11 @@ func (srh *FIFOReponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 //	 <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=13>; rel="prev"`
 //
 // See: https://docs.github.com/en/rest/guides/traversing-with-pagination
-type PaginatedReponseHandler struct {
+type PaginatedResponseHandler struct {
 	ResponsePages [][]byte
 }
 
-func (prh *PaginatedReponseHandler) getCurrentPage(r *http.Request) int {
+func (prh *PaginatedResponseHandler) getCurrentPage(r *http.Request) int {
 	strPage := r.URL.Query().Get("page")
 
 	if strPage == "" {
@@ -81,7 +81,7 @@ func (prh *PaginatedReponseHandler) getCurrentPage(r *http.Request) int {
 	panic(fmt.Sprintf("invalid page: %s", strPage))
 }
 
-func (prh *PaginatedReponseHandler) generateLinkHeader(
+func (prh *PaginatedResponseHandler) generateLinkHeader(
 	w http.ResponseWriter,
 	r *http.Request,
 ) {
@@ -105,7 +105,7 @@ func (prh *PaginatedReponseHandler) generateLinkHeader(
 }
 
 // ServeHTTP implementation of `http.Handler`
-func (prh *PaginatedReponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (prh *PaginatedResponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	prh.generateLinkHeader(w, r)
 	w.Write(prh.ResponsePages[prh.getCurrentPage(r)-1])
 }

--- a/src/mock/server.go
+++ b/src/mock/server.go
@@ -37,7 +37,7 @@ func (srh *FIFOResponseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	srh.lock.Lock()
 	defer srh.lock.Unlock()
 
-	if srh.CurrentIndex >= len(srh.Responses) {
+	if srh.CurrentIndex == len(srh.Responses) {
 		panic(fmt.Sprintf(
 			"go-github-mock: no more mocks available for %s",
 			r.URL.Path,

--- a/src/mock/server_options.go
+++ b/src/mock/server_options.go
@@ -65,7 +65,7 @@ func WithRequestMatch(
 		}
 	}
 
-	return WithRequestMatchHandler(ep, &FIFOReponseHandler{
+	return WithRequestMatchHandler(ep, &FIFOResponseHandler{
 		Responses: responses,
 	})
 }
@@ -118,7 +118,7 @@ func WithRequestMatchPages(
 		p = append(p, MustMarshal(r))
 	}
 
-	return WithRequestMatchHandler(ep, &PaginatedReponseHandler{
+	return WithRequestMatchHandler(ep, &PaginatedResponseHandler{
 		ResponsePages: p,
 	})
 }


### PR DESCRIPTION
- when `CurrentIndex` == `len(Responses)`
it means that if you will try to get responses[CurrentIndex] will make out of index panic.
we are expecting to panic [from here](https://github.com/ElisarEisenbach/go-github-mock/blob/bb3d3b6b1968538665a5143c9124dc0bb8768394/src/mock/server.go#L41-L44)
- fix typo reponse instead of response
