### PR TITLE
feat(deps): update go-github to v59

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,16 @@
 module github.com/migueleliasweb/go-github-mock
 
-go 1.16
+go 1.21
 
 require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/go-kit/log v0.2.1
-	github.com/google/go-github/v56 v56.0.0
+	github.com/google/go-github/v59 v59.0.0
 	github.com/gorilla/mux v1.8.0
 	golang.org/x/time v0.3.0
+)
+
+require (
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,10 +5,10 @@ github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBj
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v56 v56.0.0 h1:TysL7dMa/r7wsQi44BjqlwaHvwlFlqkK8CtBWCX3gb4=
-github.com/google/go-github/v56 v56.0.0/go.mod h1:D8cdcX98YWJvi7TLo7zM4/h8ZTx6u6fwGEkCdisopo0=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v59 v59.0.0 h1:7h6bgpF5as0YQLLkEiVqpgtJqjimMYhBkD4jT5aN3VA=
+github.com/google/go-github/v59 v59.0.0/go.mod h1:rJU4R0rQHFVFDOkqGWxfLNo6vEk4dv40oDjhV/gH6wM=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=

--- a/src/mock/endpointpattern_test.go
+++ b/src/mock/endpointpattern_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v56/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func TestRepoGetContents(t *testing.T) {

--- a/src/mock/server_options_external_test.go
+++ b/src/mock/server_options_external_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v56/github"
+	"github.com/google/go-github/v59/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 )
 

--- a/src/mock/server_options_test.go
+++ b/src/mock/server_options_test.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"testing"
 
-	"github.com/google/go-github/v56/github"
+	"github.com/google/go-github/v59/github"
 	"github.com/gorilla/mux"
 )
 

--- a/src/mock/server_test.go
+++ b/src/mock/server_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v56/github"
+	"github.com/google/go-github/v59/github"
 )
 
 func TestNewMockedHTTPClient(t *testing.T) {

--- a/src/mock/utils.go
+++ b/src/mock/utils.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/google/go-github/v56/github"
+	"github.com/google/go-github/v59/github"
 )
 
 // MustMarshal helper function that wraps json.Marshal


### PR DESCRIPTION
https://github.com/google/go-github/releases/tag/v59.0.0
[CHANGELOG](https://github.com/google/go-github/compare/v56.0.0...v59.0.0)