### PR TITLE
make GetReposContentsByOwnerByRepoByPath path optional

### DIFF
--- a/src/mock/endpointpattern.go
+++ b/src/mock/endpointpattern.go
@@ -2908,7 +2908,7 @@ var GetReposCompareByOwnerByRepoByBasehead EndpointPattern = EndpointPattern{
 }
 
 var GetReposContentsByOwnerByRepoByPath EndpointPattern = EndpointPattern{
-	Pattern: "/repos/{owner}/{repo}/contents/{path:.+}",
+	Pattern: "/repos/{owner}/{repo}/contents/{path:.*}",
 	Method:  "GET",
 }
 


### PR DESCRIPTION
The Github [docs](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content) for getting repository content state

> Gets the contents of a file or directory in a repository. Specify the file path or directory with the path parameter. **If you omit the path parameter,** you will receive the contents of the repository's root directory.

The docs are incorrect and mark the path as required. This PR makes the path optional.