### PR TITLE
make GetReposContentsByOwnerByRepoByPath path optional

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/migueleliasweb/go-github-mock
 
-go 1.23
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	github.com/buger/jsonparser v1.1.1
-	github.com/google/go-github/v69 v69.2.0
+	github.com/google/go-github/v71 v71.0.0
 	github.com/gorilla/mux v1.8.0
 	golang.org/x/mod v0.17.0
 	golang.org/x/text v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,10 @@
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
-github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v71 v71.0.0 h1:Zi16OymGKZZMm8ZliffVVJ/Q9YZreDKONCr+WUd0Z30=
+github.com/google/go-github/v71 v71.0.0/go.mod h1:URZXObp2BLlMjwu0O8g4y6VBneUj2bCHgnI8FfgZ51M=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/buger/jsonparser"
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v71/github"
 
 	"github.com/migueleliasweb/go-github-mock/src/gen"
 	"golang.org/x/mod/modfile"
@@ -161,7 +161,7 @@ func updateGoGithubDep() {
 		}
 	}
 
-	// e.g. "v69.2.0" => "v69"
+	// e.g. "v71.0.0" => "v69"
 	latestGoGithubPath := "github.com/google/go-github/" + strings.Split(*releaseInfo.TagName, ".")[0]
 	latestGoGithubVersion := *releaseInfo.TagName
 

--- a/src/mock/endpointpattern.go
+++ b/src/mock/endpointpattern.go
@@ -157,6 +157,11 @@ var GetCodesOfConductByKey EndpointPattern = EndpointPattern{
 	Method:  "GET",
 }
 
+var PostCredentialsRevoke EndpointPattern = EndpointPattern{
+	Pattern: "/credentials/revoke",
+	Method:  "POST",
+}
+
 var GetEmojis EndpointPattern = EndpointPattern{
 	Pattern: "/emojis",
 	Method:  "GET",
@@ -842,6 +847,31 @@ var DeleteOrgsBlocksByOrgByUsername EndpointPattern = EndpointPattern{
 	Method:  "DELETE",
 }
 
+var GetOrgsCampaignsByOrg EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/campaigns",
+	Method:  "GET",
+}
+
+var PostOrgsCampaignsByOrg EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/campaigns",
+	Method:  "POST",
+}
+
+var GetOrgsCampaignsByOrgByCampaignNumber EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/campaigns/{campaign_number}",
+	Method:  "GET",
+}
+
+var PatchOrgsCampaignsByOrgByCampaignNumber EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/campaigns/{campaign_number}",
+	Method:  "PATCH",
+}
+
+var DeleteOrgsCampaignsByOrgByCampaignNumber EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/campaigns/{campaign_number}",
+	Method:  "DELETE",
+}
+
 var GetOrgsCodeScanningAlertsByOrg EndpointPattern = EndpointPattern{
 	Pattern: "/orgs/{org}/code-scanning/alerts",
 	Method:  "GET",
@@ -994,11 +1024,6 @@ var DeleteOrgsCopilotBillingSelectedUsersByOrg EndpointPattern = EndpointPattern
 
 var GetOrgsCopilotMetricsByOrg EndpointPattern = EndpointPattern{
 	Pattern: "/orgs/{org}/copilot/metrics",
-	Method:  "GET",
-}
-
-var GetOrgsCopilotUsageByOrg EndpointPattern = EndpointPattern{
-	Pattern: "/orgs/{org}/copilot/usage",
 	Method:  "GET",
 }
 
@@ -1210,6 +1235,26 @@ var DeleteOrgsInvitationsByOrgByInvitationId EndpointPattern = EndpointPattern{
 var GetOrgsInvitationsTeamsByOrgByInvitationId EndpointPattern = EndpointPattern{
 	Pattern: "/orgs/{org}/invitations/{invitation_id}/teams",
 	Method:  "GET",
+}
+
+var GetOrgsIssueTypesByOrg EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/issue-types",
+	Method:  "GET",
+}
+
+var PostOrgsIssueTypesByOrg EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/issue-types",
+	Method:  "POST",
+}
+
+var PutOrgsIssueTypesByOrgByIssueTypeId EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/issue-types/{issue_type_id}",
+	Method:  "PUT",
+}
+
+var DeleteOrgsIssueTypesByOrgByIssueTypeId EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/issue-types/{issue_type_id}",
+	Method:  "DELETE",
 }
 
 var GetOrgsIssuesByOrg EndpointPattern = EndpointPattern{
@@ -1669,11 +1714,6 @@ var GetOrgsSettingsNetworkSettingsByOrgByNetworkSettingsId EndpointPattern = End
 
 var GetOrgsTeamCopilotMetricsByOrgByTeamSlug EndpointPattern = EndpointPattern{
 	Pattern: "/orgs/{org}/team/{team_slug}/copilot/metrics",
-	Method:  "GET",
-}
-
-var GetOrgsTeamCopilotUsageByOrgByTeamSlug EndpointPattern = EndpointPattern{
-	Pattern: "/orgs/{org}/team/{team_slug}/copilot/usage",
 	Method:  "GET",
 }
 
@@ -2908,17 +2948,17 @@ var GetReposCompareByOwnerByRepoByBasehead EndpointPattern = EndpointPattern{
 }
 
 var GetReposContentsByOwnerByRepoByPath EndpointPattern = EndpointPattern{
-	Pattern: "/repos/{owner}/{repo}/contents/{path:.+}",
+	Pattern: "/repos/{owner}/{repo}/contents/{path:.*}",
 	Method:  "GET",
 }
 
 var PutReposContentsByOwnerByRepoByPath EndpointPattern = EndpointPattern{
-	Pattern: "/repos/{owner}/{repo}/contents/{path:.+}",
+	Pattern: "/repos/{owner}/{repo}/contents/{path:.*}",
 	Method:  "PUT",
 }
 
 var DeleteReposContentsByOwnerByRepoByPath EndpointPattern = EndpointPattern{
-	Pattern: "/repos/{owner}/{repo}/contents/{path:.+}",
+	Pattern: "/repos/{owner}/{repo}/contents/{path:.*}",
 	Method:  "DELETE",
 }
 
@@ -5422,11 +5462,6 @@ var GetEnterprisesCopilotMetricsByEnterprise EndpointPattern = EndpointPattern{
 	Method:  "GET",
 }
 
-var GetEnterprisesCopilotUsageByEnterprise EndpointPattern = EndpointPattern{
-	Pattern: "/enterprises/{enterprise}/copilot/usage",
-	Method:  "GET",
-}
-
 var GetEnterprisesLicenseSyncStatusByEnterprise EndpointPattern = EndpointPattern{
 	Pattern: "/enterprises/{enterprise}/license-sync-status",
 	Method:  "GET",
@@ -5567,11 +5602,6 @@ var GetEnterprisesTeamCopilotMetricsByEnterpriseByTeamSlug EndpointPattern = End
 	Method:  "GET",
 }
 
-var GetEnterprisesTeamCopilotUsageByEnterpriseByTeamSlug EndpointPattern = EndpointPattern{
-	Pattern: "/enterprises/{enterprise}/team/{team_slug}/copilot/usage",
-	Method:  "GET",
-}
-
 var PostEnterprisesByEnterpriseBySecurityProductByEnablement EndpointPattern = EndpointPattern{
 	Pattern: "/enterprises/{enterprise}/{security_product}/{enablement}",
 	Method:  "POST",
@@ -5665,6 +5695,11 @@ var PatchOrgsCustomRolesByOrgByRoleId EndpointPattern = EndpointPattern{
 var DeleteOrgsCustomRolesByOrgByRoleId EndpointPattern = EndpointPattern{
 	Pattern: "/orgs/{org}/custom_roles/{role_id}",
 	Method:  "DELETE",
+}
+
+var GetOrgsDismissalRequestsSecretScanningByOrg EndpointPattern = EndpointPattern{
+	Pattern: "/orgs/{org}/dismissal-requests/secret-scanning",
+	Method:  "GET",
 }
 
 var GetOrgsExternalGroupByOrgByGroupId EndpointPattern = EndpointPattern{
@@ -5770,6 +5805,21 @@ var PatchReposBypassRequestsSecretScanningByOwnerByRepoByBypassRequestNumber End
 var DeleteReposBypassResponsesSecretScanningByOwnerByRepoByBypassResponseId EndpointPattern = EndpointPattern{
 	Pattern: "/repos/{owner}/{repo}/bypass-responses/secret-scanning/{bypass_response_id}",
 	Method:  "DELETE",
+}
+
+var GetReposDismissalRequestsSecretScanningByOwnerByRepo EndpointPattern = EndpointPattern{
+	Pattern: "/repos/{owner}/{repo}/dismissal-requests/secret-scanning",
+	Method:  "GET",
+}
+
+var GetReposDismissalRequestsSecretScanningByOwnerByRepoByAlertNumber EndpointPattern = EndpointPattern{
+	Pattern: "/repos/{owner}/{repo}/dismissal-requests/secret-scanning/{alert_number}",
+	Method:  "GET",
+}
+
+var PatchReposDismissalRequestsSecretScanningByOwnerByRepoByAlertNumber EndpointPattern = EndpointPattern{
+	Pattern: "/repos/{owner}/{repo}/dismissal-requests/secret-scanning/{alert_number}",
+	Method:  "PATCH",
 }
 
 var PutReposLfsByOwnerByRepo EndpointPattern = EndpointPattern{

--- a/src/mock/endpointpattern_test.go
+++ b/src/mock/endpointpattern_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v71/github"
 )
 
 func TestRepoGetContents(t *testing.T) {
@@ -58,6 +58,80 @@ func TestRepoGetContents(t *testing.T) {
 						*(fileContent.Content),
 						*rc.Content,
 					)
+				}
+
+				if err != nil {
+					t.Errorf(
+						"err is %s, want nil",
+						err.Error(),
+					)
+				}
+			}
+		}(c.repositoryContent))
+	}
+}
+
+func TestRepoGetContentsForDirectory(t *testing.T) {
+	cases := []struct {
+		name              string
+		path              string
+		repositoryContent []*github.RepositoryContent
+	}{
+		{
+			name: "rootDirectory",
+			path: "",
+			repositoryContent: []*github.RepositoryContent{
+				{
+					Name:        github.Ptr("a.yaml"),
+					DownloadURL: github.Ptr("https://raw.githubusercontent.com/foo/bar/a.yaml"),
+				},
+				{
+					Name:        github.Ptr("b.json"),
+					DownloadURL: github.Ptr("https://raw.githubusercontent.com/foo/bar/b.json"),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(rc []*github.RepositoryContent) func(t *testing.T) {
+			return func(t *testing.T) {
+				mockedHTTPClient := NewMockedHTTPClient(
+					WithRequestMatch(
+						GetReposContentsByOwnerByRepoByPath,
+						rc,
+					),
+				)
+
+				client := github.NewClient(mockedHTTPClient)
+
+				ctx := context.Background()
+
+				_, dirContent, _, err := client.Repositories.GetContents(
+					ctx,
+					"foo",
+					"bar",
+					c.path,
+					&github.RepositoryContentGetOptions{},
+				)
+
+				if len(dirContent) != len(rc) {
+					t.Errorf(
+						"dirContent length is %d, want %d",
+						len(dirContent),
+						len(rc),
+					)
+				}
+
+				for i := range rc {
+					if rc[i] == dirContent[1] {
+						t.Errorf(
+							"dirContent element at %d is '%s', want '%s'",
+							i,
+							*dirContent[i].Name,
+							*rc[i].Name,
+						)
+					}
 				}
 
 				if err != nil {

--- a/src/mock/server_options_external_test.go
+++ b/src/mock/server_options_external_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v71/github"
 	"github.com/migueleliasweb/go-github-mock/src/mock"
 )
 

--- a/src/mock/server_options_test.go
+++ b/src/mock/server_options_test.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v71/github"
 	"github.com/gorilla/mux"
 )
 

--- a/src/mock/server_test.go
+++ b/src/mock/server_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v71/github"
 )
 
 func TestNewMockedHTTPClient(t *testing.T) {

--- a/src/mock/utils.go
+++ b/src/mock/utils.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v71/github"
 )
 
 // MustMarshal helper function that wraps json.Marshal


### PR DESCRIPTION
This PR also updates from v69-v71 as a side effect of re-running mock generation.

This change extends the work done by @szesch based on the PR commentary in https://github.com/migueleliasweb/go-github-mock/pull/81